### PR TITLE
r-sf rebuild with geos

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   # If this is a new build for the same version, increment the build number.
-  number: 1
+  number: 2
   # no skip
 
   # This is required to make R link correctly on Linux.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,9 +50,9 @@ requirements:
     - r-magrittr
     - r-s2 >=1.1.0
     - r-units >=0.7_0
-    - libgdal {{ libgdal }}
-    - geos {{ geos }}
-    - proj {{ proj }}
+    - libgdal
+    - geos
+    - proj
   run:
     - r-base
     - {{native}}gcc-libs         # [win]


### PR DESCRIPTION
Rebuild `geos`'s downstream **R** packages.
See https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=geos

The package has been built for `linux-64` on the dev machine and uploaded to the testing channel https://anaconda.org/skupr/repo.

### Actions:

- Bump build number to `2`
- Remove jinja2 stuff because I'm rebuilding the package from the `aggregateR` repo, which doesn't have cbc.yaml with those basic packages. 

### Notes:
- I'm rebuilding `r-sf` separately because its feedstock resides in `AnacondaRecipes` org and the `aggregate` repo. Other `geos`'s downstream **R** packages I'm rebuilding here https://github.com/AnacondaRecipes/aggregateR/pull/15